### PR TITLE
Added mongodb in package dependencies (required by mongoskin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jsonschema" : "*",
     "merge": "*",
     "method-override": "*",
+    "mongodb": "2.*",
     "mongoskin": "*",
     "morgan": "*",
     "netmask": "*",


### PR DESCRIPTION
If mongodb package is not installed we have this warning `npm WARN mongoskin@2.1.0 requires a peer of mongodb@^2.0 but none was installed.`
